### PR TITLE
Replace AC_PATH_PROG with AC_PATH_TOOL to fix cross compiling

### DIFF
--- a/m4/ax_icuio.m4
+++ b/m4/ax_icuio.m4
@@ -43,7 +43,7 @@ AC_DEFUN([AX_ICUIO], [
   AC_LANG_PUSH([C])
   AC_REQUIRE([AC_PROG_CPP])dnl
   AC_REQUIRE([AC_PROG_SED])dnl
-  AC_PATH_PROG([PKG_CONFIG], [pkg-config], [:])
+  AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [:])
   AS_IF([test "${PKG_CONFIG}" = :], [AC_MSG_ERROR([The 'pkg-config' command was not found])])
 
   ICU_PKG=


### PR DESCRIPTION
[It has been reported](https://bugs.debian.org/989954) that cif_api has issues with cross compiling. A simple solution for this issue is to replace `AC_PATH_PROG` with `AC_PATH_TOOL` in `m4/ax_icuio.m4`. This will use pkg-config for the target platform, not the one of the builder.